### PR TITLE
Add Aurora Orbit visualizer with WebGL and Canvas fallback

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,60 +1,186 @@
-/* app.js (cinema fit fix + Esc exit) */
+import { AuroraOrbitVisualizer } from './visualizers/aurora.js';
+import { AuroraOrbit2DVisualizer } from './visualizers/aurora2d.js';
+
+class VisualizerManager {
+  constructor() {
+    this.container = null;
+    this.analyser = null;
+    this.impl = null;
+    this.lastWidth = 0;
+    this.lastHeight = 0;
+    this.activeType = null;
+    this.fallbackCanvas = null;
+    this.quality = this._detectDefaultQuality();
+  }
+
+  _detectDefaultQuality() {
+    const dpr = window.devicePixelRatio || 1;
+    const isMobile = /Mobi|Android/i.test(navigator.userAgent) || window.innerWidth < 820;
+    if (isMobile) {
+      if (dpr > 3.0) return 'low';
+      return 'medium';
+    }
+    if (dpr > 2.6) return 'medium';
+    return 'high';
+  }
+
+  static supportsWebGL() {
+    if (typeof VisualizerManager._webglCapable !== 'undefined') {
+      return VisualizerManager._webglCapable;
+    }
+    let support = false;
+    try {
+      const canvas = document.createElement('canvas');
+      support = !!(canvas.getContext('webgl2') || canvas.getContext('webgl') || canvas.getContext('experimental-webgl'));
+    } catch (e) {
+      support = false;
+    }
+    VisualizerManager._webglCapable = support;
+    return support;
+  }
+
+  init(container, analyser) {
+    if (this.impl) return;
+    this.container = container;
+    this.analyser = analyser;
+    this.fallbackCanvas = container.querySelector('#vis');
+    this._create(true);
+  }
+
+  _create(preferWebGL) {
+    if (!this.container || !this.analyser) return;
+    if (this.impl) {
+      this.impl.dispose();
+      this.impl = null;
+    }
+
+    if (preferWebGL && VisualizerManager.supportsWebGL()) {
+      try {
+        const vis = new AuroraOrbitVisualizer();
+        vis.init(this.container, this.analyser);
+        if (typeof vis.setQuality === 'function') vis.setQuality(this.quality);
+        if (typeof vis.onContextLost === 'function') {
+          vis.onContextLost(() => {
+            this._switchToFallback();
+          });
+        }
+        this.impl = vis;
+        this.activeType = 'webgl';
+        if (this.fallbackCanvas) this.fallbackCanvas.style.display = 'none';
+      } catch (err) {
+        console.warn('AuroraOrbitVisualizer failed, falling back to 2D:', err);
+        this.impl = null;
+        this._create(false);
+        return;
+      }
+    } else {
+      const fallback = new AuroraOrbit2DVisualizer();
+      fallback.init(this.container, this.analyser);
+      if (typeof fallback.setQuality === 'function') fallback.setQuality(this.quality);
+      this.impl = fallback;
+      this.activeType = '2d';
+      if (this.fallbackCanvas) this.fallbackCanvas.style.display = 'block';
+    }
+
+    const width = this.lastWidth || this.container.clientWidth;
+    const height = this.lastHeight || this.container.clientHeight;
+    this.resize(width, height);
+  }
+
+  _switchToFallback() {
+    if (this.activeType === '2d') return;
+    if (this.impl) {
+      this.impl.dispose();
+      this.impl = null;
+    }
+    this._create(false);
+  }
+
+  resize(width, height) {
+    if (!width || !height) return;
+    this.lastWidth = width;
+    this.lastHeight = height;
+    if (this.impl && typeof this.impl.resize === 'function') {
+      this.impl.resize(width, height);
+    }
+  }
+
+  update(freq, wave, dt) {
+    if (this.impl && typeof this.impl.update === 'function') {
+      this.impl.update(freq, wave, dt);
+    }
+  }
+
+  setQuality(level) {
+    this.quality = level;
+    if (this.impl && typeof this.impl.setQuality === 'function') {
+      this.impl.setQuality(level);
+    }
+  }
+
+  dispose() {
+    if (this.impl) {
+      this.impl.dispose();
+      this.impl = null;
+    }
+    this.activeType = null;
+    if (this.fallbackCanvas) this.fallbackCanvas.style.display = 'block';
+  }
+}
+
 (() => {
   const $ = (sel) => document.querySelector(sel);
-  const $$ = (sel) => Array.from(document.querySelectorAll(sel));
 
-  // Elements
-  const audioEl = document.querySelector("#audio");
-  const canvas = document.querySelector("#vis");
-  const ctx2d = canvas.getContext("2d", { alpha: false, desynchronized: true });
-  const playPauseBtn = document.querySelector("#playPause");
-  const addBtn = document.querySelector("#btn-add");
-  const fileInput = document.querySelector("#fileInput");
-  const trackListEl = document.querySelector("#trackList");
-  const dropzone = document.querySelector("#dropzone");
-  const timeEl = document.querySelector("#time");
-  const seekEl = document.querySelector("#seek");
-  const volEl = document.querySelector("#volume");
-  const cinemaBtn = document.querySelector("#btn-cinema");
-  const exitCinemaBtn = document.querySelector("#btn-exit-cinema");
-  const qualitySel = document.querySelector("#quality");
+  const audioEl = $('#audio');
+  const stage = document.querySelector('.stage');
+  const playPauseBtn = $('#playPause');
+  const addBtn = $('#btn-add');
+  const fileInput = $('#fileInput');
+  const trackListEl = $('#trackList');
+  const dropzone = $('#dropzone');
+  const timeEl = $('#time');
+  const seekEl = $('#seek');
+  const volEl = $('#volume');
+  const cinemaBtn = $('#btn-cinema');
+  const exitCinemaBtn = $('#btn-exit-cinema');
+  const qualitySel = $('#quality');
 
-  // Resize canvas
-  function fitCanvas() {
-    const dpr = Math.min(window.devicePixelRatio || 1, 2);
-    const { clientWidth: w, clientHeight: h } = canvas;
-    canvas.width = Math.floor(w * dpr);
-    canvas.height = Math.floor(h * dpr);
-    ctx2d.setTransform(dpr, 0, 0, dpr, 0, 0);
-    ctx2d.fillStyle = "#07090c";
-    ctx2d.fillRect(0, 0, w, h);
-  }
-  new ResizeObserver(fitCanvas).observe(canvas);
-
-  // Audio & analysis
-  let audioCtx = null;
-  let analyser = null;
-  let srcNode = null;
-  let freqData = null;
-  let timeData = null;
+  const visualizerManager = new VisualizerManager();
+  qualitySel.value = visualizerManager.quality;
 
   const STATE = {
     tracks: [],
     current: -1,
     playing: false,
     rafId: null,
-    quality: "high",
-    bars: 48,
-    smoothing: 0.82,
-    peakHold: [],
-    peakDecay: 0.01,
+    quality: qualitySel.value,
+    lastFrameTime: performance.now()
   };
+
+  let audioCtx = null;
+  let analyser = null;
+  let srcNode = null;
+  let freqData = null;
+  let timeData = null;
+
+  const stageResizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      const { width, height } = entry.contentRect;
+      visualizerManager.resize(width, height);
+    }
+  });
+  stageResizeObserver.observe(stage);
+
+  function scheduleResize() {
+    const rect = stage.getBoundingClientRect();
+    visualizerManager.resize(rect.width, rect.height);
+  }
 
   const fmtTime = (sec) => {
     if (!isFinite(sec)) sec = 0;
     const m = Math.floor(sec / 60);
     const s = Math.floor(sec % 60);
-    return `${m}:${s.toString().padStart(2, "0")}`;
+    return `${m}:${s.toString().padStart(2, '0')}`;
   };
 
   function ensureAudio() {
@@ -62,7 +188,7 @@
     audioCtx = new (window.AudioContext || window.webkitAudioContext)();
     analyser = audioCtx.createAnalyser();
     analyser.fftSize = 2048;
-    analyser.smoothingTimeConstant = STATE.smoothing;
+    analyser.smoothingTimeConstant = 0.82;
     analyser.minDecibels = -85;
     analyser.maxDecibels = -15;
 
@@ -76,10 +202,19 @@
     srcNode.connect(gain);
     gain.connect(analyser);
     analyser.connect(audioCtx.destination);
+
+    visualizerManager.init(stage, analyser);
+    visualizerManager.setQuality(STATE.quality);
+    if (freqData && timeData) {
+      freqData.fill(0);
+      timeData.fill(128);
+      visualizerManager.update(freqData, timeData, 0);
+    }
+    scheduleResize();
   }
 
   function addFiles(fileList) {
-    const files = Array.from(fileList).filter(f => f.type.startsWith("audio/"));
+    const files = Array.from(fileList).filter((f) => f.type.startsWith('audio/'));
     if (!files.length) return;
     files.forEach((file) => {
       const id = `${file.name}-${file.size}-${file.lastModified}`;
@@ -91,34 +226,36 @@
   }
 
   function renderTrackList() {
-    trackListEl.innerHTML = "";
+    trackListEl.innerHTML = '';
     STATE.tracks.forEach((t, i) => {
-      const li = document.createElement("li");
+      const li = document.createElement('li');
       li.dataset.idx = i;
-      if (i === STATE.current) li.classList.add("active");
-      const icon = document.createElement("span");
-      icon.textContent = "♪";
-      icon.style.opacity = "0.7";
-      const meta = document.createElement("div");
-      meta.className = "meta";
-      const title = document.createElement("div");
-      title.className = "title";
+      if (i === STATE.current) li.classList.add('active');
+      const icon = document.createElement('span');
+      icon.textContent = '♪';
+      icon.style.opacity = '0.7';
+      const meta = document.createElement('div');
+      meta.className = 'meta';
+      const title = document.createElement('div');
+      title.className = 'title';
       title.textContent = t.name;
-      const sub = document.createElement("div");
-      sub.className = "sub";
-      sub.textContent = t.duration ? fmtTime(t.duration) : "—:—";
-      meta.appendChild(title); meta.appendChild(sub);
-      li.appendChild(icon); li.appendChild(meta);
-      li.addEventListener("click", () => loadTrack(i, true));
+      const sub = document.createElement('div');
+      sub.className = 'sub';
+      sub.textContent = t.duration ? fmtTime(t.duration) : '—:—';
+      meta.appendChild(title);
+      meta.appendChild(sub);
+      li.appendChild(icon);
+      li.appendChild(meta);
+      li.addEventListener('click', () => loadTrack(i, true));
       trackListEl.appendChild(li);
     });
   }
 
-  function loadTrack(idx, autoplay=false) {
+  function loadTrack(idx, autoplay = false) {
     if (idx < 0 || idx >= STATE.tracks.length) return;
     STATE.current = idx;
-    Array.from(document.querySelectorAll(".track-list li")).forEach((li, i) => {
-      li.classList.toggle("active", i === idx);
+    Array.from(document.querySelectorAll('.track-list li')).forEach((li, i) => {
+      li.classList.toggle('active', i === idx);
     });
 
     const t = STATE.tracks[idx];
@@ -140,26 +277,37 @@
       await audioCtx.resume();
       await audioEl.play();
       STATE.playing = true;
-      playPauseBtn.textContent = "Pause";
-      loop();
+      playPauseBtn.textContent = 'Pause';
+      STATE.lastFrameTime = performance.now();
+      if (!STATE.rafId) STATE.rafId = requestAnimationFrame(loop);
     } catch (e) {
-      console.warn("Play failed:", e);
+      console.warn('Play failed:', e);
     }
   }
 
   function pause() {
     audioEl.pause();
     STATE.playing = false;
-    playPauseBtn.textContent = "Play";
-    cancelAnimationFrame(STATE.rafId);
+    playPauseBtn.textContent = 'Play';
+    if (STATE.rafId) cancelAnimationFrame(STATE.rafId);
     STATE.rafId = null;
   }
 
-  playPauseBtn.addEventListener("click", () => {
+  function loop(now) {
+    STATE.rafId = requestAnimationFrame(loop);
+    if (!analyser) return;
+    analyser.getByteFrequencyData(freqData);
+    analyser.getByteTimeDomainData(timeData);
+    const dt = Math.min(0.12, Math.max(0.001, (now - STATE.lastFrameTime) / 1000 || 0.016));
+    STATE.lastFrameTime = now;
+    visualizerManager.update(freqData, timeData, dt);
+  }
+
+  playPauseBtn.addEventListener('click', () => {
     STATE.playing ? pause() : play();
   });
 
-  audioEl.addEventListener("ended", () => {
+  audioEl.addEventListener('ended', () => {
     const next = STATE.current + 1;
     if (next < STATE.tracks.length) {
       loadTrack(next, true);
@@ -169,19 +317,19 @@
     }
   });
 
-  volEl.addEventListener("input", () => {
+  volEl.addEventListener('input', () => {
     ensureAudio();
     audioEl.volume = parseFloat(volEl.value);
   });
 
-  seekEl.addEventListener("input", () => {
+  seekEl.addEventListener('input', () => {
     const t = STATE.tracks[STATE.current];
     if (!t || !isFinite(t.duration) || !t.duration) return;
     const ratio = parseFloat(seekEl.value);
     audioEl.currentTime = ratio * t.duration;
   });
 
-  audioEl.addEventListener("timeupdate", updateTimeUI);
+  audioEl.addEventListener('timeupdate', updateTimeUI);
   function updateTimeUI() {
     const t = STATE.tracks[STATE.current];
     const cur = audioEl.currentTime || 0;
@@ -190,166 +338,70 @@
     if (dur > 0) seekEl.value = (cur / dur).toFixed(3);
   }
 
-  ["dragenter", "dragover"].forEach(evt =>
-    dropzone.addEventListener(evt, (e) => { e.preventDefault(); e.stopPropagation(); dropzone.classList.add("drag"); })
+  ['dragenter', 'dragover'].forEach((evt) =>
+    dropzone.addEventListener(evt, (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      dropzone.classList.add('drag');
+    })
   );
-  ["dragleave", "drop"].forEach(evt =>
-    dropzone.addEventListener(evt, (e) => { e.preventDefault(); e.stopPropagation(); dropzone.classList.remove("drag"); })
+  ['dragleave', 'drop'].forEach((evt) =>
+    dropzone.addEventListener(evt, (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      dropzone.classList.remove('drag');
+    })
   );
-  dropzone.addEventListener("drop", (e) => {
+  dropzone.addEventListener('drop', (e) => {
     addFiles(e.dataTransfer.files);
   });
 
-  addBtn.addEventListener("click", () => fileInput.click());
-  fileInput.addEventListener("change", (e) => addFiles(e.target.files));
+  addBtn.addEventListener('click', () => fileInput.click());
+  fileInput.addEventListener('change', (e) => addFiles(e.target.files));
 
-  // Enter/exit cinema: force viewport to top to avoid any residual scroll
-  cinemaBtn.addEventListener("click", () => {
-    document.body.classList.toggle("cinema");
-    if (document.body.classList.contains("cinema")) {
-      window.scrollTo({ top: 0, left: 0, behavior: "instant" });
+  cinemaBtn.addEventListener('click', () => {
+    document.body.classList.toggle('cinema');
+    if (document.body.classList.contains('cinema')) {
+      window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
     }
-    setTimeout(fitCanvas, 50);
+    setTimeout(scheduleResize, 60);
   });
 
-  // Exit button only shows in cinema
-  exitCinemaBtn.addEventListener("click", () => {
-    if (document.body.classList.contains("cinema")) {
-      document.body.classList.remove("cinema");
-      setTimeout(fitCanvas, 50);
+  exitCinemaBtn.addEventListener('click', () => {
+    if (document.body.classList.contains('cinema')) {
+      document.body.classList.remove('cinema');
+      setTimeout(scheduleResize, 60);
     }
   });
 
-  qualitySel.addEventListener("change", () => {
+  qualitySel.addEventListener('change', () => {
     STATE.quality = qualitySel.value;
-    if (STATE.quality === "high") {
-      STATE.bars = 64;
-      STATE.peakDecay = 0.012;
-    } else if (STATE.quality === "medium") {
-      STATE.bars = 48;
-      STATE.peakDecay = 0.016;
-    } else {
-      STATE.bars = 32;
-      STATE.peakDecay = 0.02;
-    }
-    STATE.peakHold = new Array(STATE.bars).fill(0);
+    visualizerManager.setQuality(STATE.quality);
+    scheduleResize();
   });
 
-  function makeLogBandMap(nFftBins, nBars, sampleRate = 44100) {
-    const nyquist = sampleRate / 2;
-    const fMin = 32, fMax = Math.min(16000, nyquist);
-    const binsPerBar = [];
-    for (let i = 0; i < nBars; i++) {
-      const t0 = i / nBars, t1 = (i + 1) / nBars;
-      const f0 = fMin * Math.pow(fMax / fMin, t0);
-      const f1 = fMin * Math.pow(fMax / fMin, t1);
-      const b0 = Math.max(0, Math.floor((f0 / nyquist) * nFftBins));
-      const b1 = Math.min(nFftBins - 1, Math.ceil((f1 / nyquist) * nFftBins));
-      binsPerBar.push([b0, Math.max(b0 + 1, b1)]);
-    }
-    return binsPerBar;
-  }
-
-  let bandMap = null;
-  function loop() {
-    STATE.rafId = requestAnimationFrame(loop);
-    if (!analyser) return;
-    analyser.getByteFrequencyData(freqData);
-    analyser.getByteTimeDomainData(timeData);
-    drawFrame(freqData, timeData);
-  }
-
-  function drawFrame(freq, wave) {
-    const W = canvas.clientWidth, H = canvas.clientHeight;
-
-    if (!bandMap || bandMap.length !== STATE.bars) {
-      bandMap = makeLogBandMap(freq.length, STATE.bars, audioCtx?.sampleRate || 44100);
-      STATE.peakHold = new Array(STATE.bars).fill(0);
-    }
-
-    ctx2d.fillStyle = "#07090c";
-    ctx2d.fillRect(0, 0, W, H);
-
-    const grad = ctx2d.createLinearGradient(0, 0, 0, H);
-    grad.addColorStop(0.0, "#b8d9ff");
-    grad.addColorStop(0.5, "#6ad1ff");
-    grad.addColorStop(1.0, "#b072ff");
-
-    const margin = 24;
-    const visH = H * 0.62;
-    const visY = (H - visH) * 0.5;
-    const gap = 3;
-    const barW = (W - margin * 2 - gap * (STATE.bars - 1)) / STATE.bars;
-
-    const bars = new Array(STATE.bars).fill(0);
-    for (let i = 0; i < STATE.bars; i++) {
-      const [b0, b1] = bandMap[i];
-      let sum = 0;
-      for (let b = b0; b < b1; b++) sum += freq[b];
-      const avg = sum / (b1 - b0);
-      const tilt = Math.pow(i / STATE.bars, 0.7) * 0.15;
-      bars[i] = Math.min(1, Math.max(0, (avg / 255) * (1 - tilt)));
-    }
-
-    ctx2d.save();
-    ctx2d.translate(margin, visY + visH);
-    ctx2d.fillStyle = grad;
-    ctx2d.strokeStyle = "rgba(255,255,255,0.08)";
-    for (let i = 0; i < STATE.bars; i++) {
-      const x = i * (barW + gap);
-      const h = Math.max(2, bars[i] * visH);
-      STATE.peakHold[i] = Math.max(STATE.peakHold[i] - STATE.peakDecay * visH, h);
-      ctx2d.fillRect(x, -h, barW, h);
-      ctx2d.strokeRect(x + 0.5, -h + 0.5, barW - 1, h - 1);
-      ctx2d.fillStyle = "rgba(255,255,255,0.6)";
-      ctx2d.fillRect(x, -STATE.peakHold[i] - 2, barW, 2);
-      ctx2d.fillStyle = grad;
-    }
-    ctx2d.restore();
-
-    const waveH = Math.min(H * 0.22, 140);
-    const waveY = H - waveH - 18;
-    ctx2d.save();
-    ctx2d.translate(0, waveY + waveH / 2);
-
-    ctx2d.lineWidth = 2;
-    ctx2d.strokeStyle = "rgba(255,255,255,0.85)";
-    ctx2d.beginPath();
-    const step = Math.max(1, Math.floor(wave.length / W));
-    for (let x = 0, i = 0; i < wave.length; i += step, x++) {
-      const v = (wave[i] - 128) / 128;
-      const y = v * (waveH * 0.48);
-      if (x === 0) ctx2d.moveTo(x, y);
-      else ctx2d.lineTo(x, y);
-    }
-    ctx2d.stroke();
-
-    ctx2d.globalAlpha = 0.35;
-    ctx2d.lineWidth = 8;
-    ctx2d.strokeStyle = "#6ad1ff";
-    ctx2d.stroke();
-    ctx2d.globalAlpha = 1;
-    ctx2d.restore();
-
-    const vignette = ctx2d.createRadialGradient(W/2, H/2, Math.min(W,H)*0.2, W/2, H/2, Math.max(W,H)*0.7);
-    vignette.addColorStop(0, "rgba(0,0,0,0)");
-    vignette.addColorStop(1, "rgba(0,0,0,0.35)");
-    ctx2d.fillStyle = vignette;
-    ctx2d.fillRect(0,0,W,H);
-  }
-
-  window.addEventListener("load", () => {
-    fitCanvas();
-    window.addEventListener("resize", fitCanvas);
+  window.addEventListener('resize', () => {
+    scheduleResize();
   });
 
-  window.addEventListener("keydown", (e) => {
-    if (e.code === "Space") { e.preventDefault(); STATE.playing ? pause() : play(); }
-    if (e.code === "ArrowRight") { audioEl.currentTime = Math.min((audioEl.currentTime||0)+5, audioEl.duration||1e9); }
-    if (e.code === "ArrowLeft") { audioEl.currentTime = Math.max((audioEl.currentTime||0)-5, 0); }
-    if (e.code === "Escape" && document.body.classList.contains("cinema")) {
-      document.body.classList.remove("cinema");
-      setTimeout(fitCanvas, 50);
+  window.addEventListener('load', () => {
+    scheduleResize();
+  });
+
+  window.addEventListener('keydown', (e) => {
+    if (e.code === 'Space') {
+      e.preventDefault();
+      STATE.playing ? pause() : play();
+    }
+    if (e.code === 'ArrowRight') {
+      audioEl.currentTime = Math.min((audioEl.currentTime || 0) + 5, audioEl.duration || 1e9);
+    }
+    if (e.code === 'ArrowLeft') {
+      audioEl.currentTime = Math.max((audioEl.currentTime || 0) - 5, 0);
+    }
+    if (e.code === 'Escape' && document.body.classList.contains('cinema')) {
+      document.body.classList.remove('cinema');
+      setTimeout(scheduleResize, 60);
     }
   });
 })();

--- a/index.html
+++ b/index.html
@@ -53,6 +53,10 @@
   </footer>
 
   <audio id="audio" crossorigin="anonymous"></audio>
-  <script src="app.js"></script>
+  <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
+  <script src="https://unpkg.com/postprocessing@6.35.3/build/postprocessing.min.js"></script>
+  <script type="module" src="visualizers/aurora.js"></script>
+  <script type="module" src="visualizers/aurora2d.js"></script>
+  <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/visualizers/aurora.js
+++ b/visualizers/aurora.js
@@ -1,0 +1,882 @@
+const THREE = window.THREE;
+const POSTPROCESSING = window.POSTPROCESSING;
+
+if (!THREE) {
+  throw new Error("Three.js is required for AuroraOrbitVisualizer");
+}
+
+// Lightweight seeded simplex noise for smooth procedural motion.
+class SimplexNoise {
+  constructor(seed = 0) {
+    let s = seed;
+    if (typeof s !== "number" || !isFinite(s)) s = Math.random() * 1e9;
+    this.p = new Uint8Array(512);
+    for (let i = 0; i < 256; i++) {
+      s = (s * 16807) % 2147483647;
+      this.p[i] = this.p[i + 256] = s & 255;
+    }
+  }
+
+  noise3D(x, y, z) {
+    const F3 = 1 / 3;
+    const G3 = 1 / 6;
+
+    const perm = this.p;
+
+    let n0 = 0, n1 = 0, n2 = 0, n3 = 0;
+
+    const s = (x + y + z) * F3;
+    const i = Math.floor(x + s);
+    const j = Math.floor(y + s);
+    const k = Math.floor(z + s);
+
+    const t = (i + j + k) * G3;
+    const X0 = i - t;
+    const Y0 = j - t;
+    const Z0 = k - t;
+    const x0 = x - X0;
+    const y0 = y - Y0;
+    const z0 = z - Z0;
+
+    let i1, j1, k1;
+    let i2, j2, k2;
+
+    if (x0 >= y0) {
+      if (y0 >= z0) {
+        i1 = 1; j1 = 0; k1 = 0;
+        i2 = 1; j2 = 1; k2 = 0;
+      } else if (x0 >= z0) {
+        i1 = 1; j1 = 0; k1 = 0;
+        i2 = 1; j2 = 0; k2 = 1;
+      } else {
+        i1 = 0; j1 = 0; k1 = 1;
+        i2 = 1; j2 = 0; k2 = 1;
+      }
+    } else {
+      if (y0 < z0) {
+        i1 = 0; j1 = 0; k1 = 1;
+        i2 = 0; j2 = 1; k2 = 1;
+      } else if (x0 < z0) {
+        i1 = 0; j1 = 1; k1 = 0;
+        i2 = 0; j2 = 1; k2 = 1;
+      } else {
+        i1 = 0; j1 = 1; k1 = 0;
+        i2 = 1; j2 = 1; k2 = 0;
+      }
+    }
+
+    const x1 = x0 - i1 + G3;
+    const y1 = y0 - j1 + G3;
+    const z1 = z0 - k1 + G3;
+    const x2 = x0 - i2 + 2 * G3;
+    const y2 = y0 - j2 + 2 * G3;
+    const z2 = z0 - k2 + 2 * G3;
+    const x3 = x0 - 1 + 3 * G3;
+    const y3 = y0 - 1 + 3 * G3;
+    const z3 = z0 - 1 + 3 * G3;
+
+    const ii = i & 255;
+    const jj = j & 255;
+    const kk = k & 255;
+
+    const grad = (hash, x, y, z) => {
+      const h = hash & 15;
+      const u = h < 8 ? x : y;
+      const v = h < 4 ? y : h === 12 || h === 14 ? x : z;
+      return ((h & 1) === 0 ? u : -u) + ((h & 2) === 0 ? v : -v);
+    };
+
+    let t0 = 0.6 - x0 * x0 - y0 * y0 - z0 * z0;
+    if (t0 > 0) {
+      t0 *= t0;
+      n0 = t0 * t0 * grad(perm[ii + perm[jj + perm[kk]]], x0, y0, z0);
+    }
+
+    let t1 = 0.6 - x1 * x1 - y1 * y1 - z1 * z1;
+    if (t1 > 0) {
+      t1 *= t1;
+      n1 = t1 * t1 * grad(perm[ii + i1 + perm[jj + j1 + perm[kk + k1]]], x1, y1, z1);
+    }
+
+    let t2 = 0.6 - x2 * x2 - y2 * y2 - z2 * z2;
+    if (t2 > 0) {
+      t2 *= t2;
+      n2 = t2 * t2 * grad(perm[ii + i2 + perm[jj + j2 + perm[kk + k2]]], x2, y2, z2);
+    }
+
+    let t3 = 0.6 - x3 * x3 - y3 * y3 - z3 * z3;
+    if (t3 > 0) {
+      t3 *= t3;
+      n3 = t3 * t3 * grad(perm[ii + 1 + perm[jj + 1 + perm[kk + 1]]], x3, y3, z3);
+    }
+
+    return 32 * (n0 + n1 + n2 + n3);
+  }
+}
+
+const QUALITY_PRESETS = {
+  high: { particles: 18000, ribbons: 4, ribbonSegments: 150, bloom: 1.25 },
+  medium: { particles: 13500, ribbons: 3, ribbonSegments: 120, bloom: 1.0 },
+  low: { particles: 9000, ribbons: 3, ribbonSegments: 90, bloom: 0.75 }
+};
+
+const BASE_GRADIENT = [
+  { h: 208 / 360, s: 0.78, l: 0.62 },
+  { h: 190 / 360, s: 0.85, l: 0.58 },
+  { h: 280 / 360, s: 0.7, l: 0.6 },
+  { h: 320 / 360, s: 0.65, l: 0.57 }
+];
+
+function makeTorusAttribute(count, majorRadius, minorRadius) {
+  const positions = new Float32Array(count * 3);
+  const angles = new Float32Array(count * 2);
+  const seeds = new Float32Array(count * 2);
+
+  for (let i = 0; i < count; i++) {
+    const theta = Math.random() * Math.PI * 2;
+    const phi = Math.random() * Math.PI * 2;
+    const jitter = (Math.random() - 0.5) * 0.1;
+    const minor = minorRadius * (1 + jitter);
+    const cosPhi = Math.cos(phi);
+    const sinPhi = Math.sin(phi);
+    const cosTheta = Math.cos(theta);
+    const sinTheta = Math.sin(theta);
+    const x = (majorRadius + minor * cosPhi) * cosTheta;
+    const y = minor * sinPhi;
+    const z = (majorRadius + minor * cosPhi) * sinTheta;
+
+    const idx3 = i * 3;
+    positions[idx3] = x;
+    positions[idx3 + 1] = y;
+    positions[idx3 + 2] = z;
+
+    const idx2 = i * 2;
+    angles[idx2] = theta;
+    angles[idx2 + 1] = phi;
+
+    seeds[idx2] = Math.random();
+    seeds[idx2 + 1] = Math.random();
+  }
+
+  return { positions, angles, seeds };
+}
+
+function makeStarfield(count, radius) {
+  const geometry = new THREE.BufferGeometry();
+  const positions = new Float32Array(count * 3);
+  const colors = new Float32Array(count * 3);
+  for (let i = 0; i < count; i++) {
+    const theta = Math.random() * Math.PI * 2;
+    const phi = Math.acos(2 * Math.random() - 1);
+    const r = radius * (0.6 + Math.random() * 0.4);
+    const sinPhi = Math.sin(phi);
+    const idx = i * 3;
+    positions[idx] = r * Math.cos(theta) * sinPhi;
+    positions[idx + 1] = r * Math.cos(phi);
+    positions[idx + 2] = r * Math.sin(theta) * sinPhi;
+    const tint = 0.7 + Math.random() * 0.3;
+    colors[idx] = 0.45 * tint;
+    colors[idx + 1] = 0.55 * tint;
+    colors[idx + 2] = 0.7 * tint;
+  }
+  geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+  const material = new THREE.PointsMaterial({
+    size: 0.08,
+    vertexColors: true,
+    depthWrite: false,
+    transparent: true,
+    opacity: 0.65
+  });
+  return new THREE.Points(geometry, material);
+}
+
+class AuroraRibbon {
+  constructor(scene, segments, palette, noise) {
+    this.segments = segments;
+    this.noise = noise;
+    this.seed = Math.random() * 1000;
+    this.phase = Math.random() * Math.PI * 2;
+    this.phiOffset = (Math.random() * 0.7 + 0.2) * (Math.random() > 0.5 ? 1 : -1);
+    this.speed = 0.12 + Math.random() * 0.08;
+    this.twist = 0.6 + Math.random() * 0.4;
+    this.baseWidth = 0.08 + Math.random() * 0.04;
+    this.palette = palette;
+
+    const vertexCount = segments * 2;
+    this.positions = new Float32Array(vertexCount * 3);
+    this.along = new Float32Array(vertexCount);
+    this.side = new Float32Array(vertexCount);
+    this.centers = new Float32Array(segments * 3);
+    this.phi = new Float32Array(segments);
+
+    const indices = new (vertexCount > 65535 ? Uint32Array : Uint16Array)((segments - 1) * 6);
+    let id = 0;
+    for (let i = 0; i < segments - 1; i++) {
+      const a = i * 2;
+      const b = a + 1;
+      const c = a + 2;
+      const d = a + 3;
+      indices[id++] = a;
+      indices[id++] = b;
+      indices[id++] = c;
+      indices[id++] = b;
+      indices[id++] = d;
+      indices[id++] = c;
+    }
+
+    for (let i = 0; i < segments; i++) {
+      const alongVal = i / (segments - 1);
+      const idx = i * 2;
+      this.along[idx] = this.along[idx + 1] = alongVal;
+      this.side[idx] = -1;
+      this.side[idx + 1] = 1;
+    }
+
+    this.geometry = new THREE.BufferGeometry();
+    this.geometry.setAttribute("position", new THREE.BufferAttribute(this.positions, 3));
+    this.geometry.setAttribute("aAlong", new THREE.BufferAttribute(this.along, 1));
+    this.geometry.setAttribute("aSide", new THREE.BufferAttribute(this.side, 1));
+    this.geometry.setIndex(new THREE.BufferAttribute(indices, 1));
+
+    this.material = new THREE.ShaderMaterial({
+      transparent: true,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+      uniforms: {
+        uTime: { value: 0 },
+        uEnergy: { value: 0 },
+        uGlow: { value: 1 },
+        uColorA: { value: new THREE.Color().setHSL(palette.h1, palette.s1, palette.l1).convertSRGBToLinear() },
+        uColorB: { value: new THREE.Color().setHSL(palette.h2, palette.s2, palette.l2).convertSRGBToLinear() }
+      },
+      vertexShader: `
+        precision mediump float;
+        uniform float uTime;
+        attribute float aAlong;
+        attribute float aSide;
+        varying float vAlong;
+        varying float vSide;
+        void main(){
+          vAlong = aAlong;
+          vSide = aSide;
+          gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        }
+      `,
+      fragmentShader: `
+        precision mediump float;
+        uniform vec3 uColorA;
+        uniform vec3 uColorB;
+        uniform float uEnergy;
+        uniform float uGlow;
+        varying float vAlong;
+        varying float vSide;
+        void main(){
+          float core = 1.0 - smoothstep(0.0, 1.0, abs(vSide));
+          float fringe = smoothstep(0.0, 0.7, core);
+          vec3 color = mix(uColorA, uColorB, pow(vAlong, 1.6));
+          color *= (0.6 + 0.4 * fringe);
+          color += vec3(0.45, 0.35, 0.6) * uEnergy * fringe;
+          float alpha = pow(core, 1.2) * uGlow;
+          if (alpha < 0.01) discard;
+          gl_FragColor = vec4(color, alpha);
+        }
+      `
+    });
+
+    this.mesh = new THREE.Mesh(this.geometry, this.material);
+    scene.add(this.mesh);
+
+    this.tmpTangent = [0, 0, 0];
+    this.tmpCenter = [0, 0, 0];
+    this.tmpBinormal = [0, 0, 0];
+  }
+
+  update(time, audio, minorRadius, amplitude, hueShift) {
+    const segments = this.segments;
+    const centers = this.centers;
+    const phiArray = this.phi;
+    const positions = this.positions;
+    const bass = audio.bass;
+    const mids = audio.mids;
+    const energy = audio.energy;
+
+    const amp = amplitude * (0.6 + 1.2 * mids);
+
+    for (let i = 0; i < segments; i++) {
+      const t = i / (segments - 1);
+      const theta = t * Math.PI * 2 + time * this.speed + this.phase;
+      const noiseVal = this.noise.noise3D(theta * 0.6, this.seed * 0.17, time * 0.35 + this.seed);
+      const wobble = this.noise.noise3D(theta * this.twist, this.seed * 0.07, time * 0.52) * 0.6;
+      const phi = this.phiOffset + wobble;
+      const minor = minorRadius * (1.0 + 0.2 * Math.sin(theta * 1.8 + this.phase)) + amp * noiseVal;
+      const cosTheta = Math.cos(theta);
+      const sinTheta = Math.sin(theta);
+      const cosPhi = Math.cos(phi);
+      const sinPhi = Math.sin(phi);
+      const x = (2.2 + (minor + amp * 0.1) * cosPhi) * cosTheta;
+      const y = (minor + amp * 0.2) * sinPhi;
+      const z = (2.2 + (minor + amp * 0.1) * cosPhi) * sinTheta;
+      const idx = i * 3;
+      centers[idx] = x;
+      centers[idx + 1] = y;
+      centers[idx + 2] = z;
+      phiArray[i] = phi;
+    }
+
+    const widthBase = this.baseWidth * (1.0 + 0.4 * bass);
+    for (let i = 0; i < segments; i++) {
+      const idx = i * 3;
+      const prevIdx = i === 0 ? 0 : (i - 1) * 3;
+      const nextIdx = i === segments - 1 ? idx : (i + 1) * 3;
+
+      const tx = centers[nextIdx] - centers[prevIdx];
+      const ty = centers[nextIdx + 1] - centers[prevIdx + 1];
+      const tz = centers[nextIdx + 2] - centers[prevIdx + 2];
+      let len = Math.hypot(tx, ty, tz) || 1;
+      const tangent = this.tmpTangent;
+      tangent[0] = tx / len;
+      tangent[1] = ty / len;
+      tangent[2] = tz / len;
+
+      const cx = centers[idx];
+      const cy = centers[idx + 1];
+      const cz = centers[idx + 2];
+
+      const toCenterX = cx;
+      const toCenterY = cy * 0.4;
+      const toCenterZ = cz;
+      len = Math.hypot(toCenterX, toCenterY, toCenterZ) || 1;
+      const normalX = toCenterX / len;
+      const normalY = toCenterY / len;
+      const normalZ = toCenterZ / len;
+
+      const binormal = this.tmpBinormal;
+      binormal[0] = tangent[1] * normalZ - tangent[2] * normalY;
+      binormal[1] = tangent[2] * normalX - tangent[0] * normalZ;
+      binormal[2] = tangent[0] * normalY - tangent[1] * normalX;
+      len = Math.hypot(binormal[0], binormal[1], binormal[2]) || 1;
+      binormal[0] /= len;
+      binormal[1] /= len;
+      binormal[2] /= len;
+
+      const wave = Math.sin(i * 0.32 + time * 1.6 + this.seed) * 0.5 + 0.5;
+      const width = widthBase * (0.8 + 0.7 * wave) * (0.7 + 0.6 * mids);
+
+      const vIdx = i * 6;
+      positions[vIdx] = cx - binormal[0] * width;
+      positions[vIdx + 1] = cy - binormal[1] * width;
+      positions[vIdx + 2] = cz - binormal[2] * width;
+      positions[vIdx + 3] = cx + binormal[0] * width;
+      positions[vIdx + 4] = cy + binormal[1] * width;
+      positions[vIdx + 5] = cz + binormal[2] * width;
+    }
+
+    this.geometry.attributes.position.needsUpdate = true;
+
+    const hueA = (this.palette.h1 + hueShift / (Math.PI * 2)) % 1;
+    const hueB = (this.palette.h2 + hueShift / (Math.PI * 2)) % 1;
+    this.material.uniforms.uColorA.value.setHSL((hueA + 1) % 1, this.palette.s1, this.palette.l1).convertSRGBToLinear();
+    this.material.uniforms.uColorB.value.setHSL((hueB + 1) % 1, this.palette.s2, this.palette.l2).convertSRGBToLinear();
+    this.material.uniforms.uEnergy.value = energy;
+    this.material.uniforms.uGlow.value = 0.8 + energy * 1.4;
+    this.material.uniforms.uTime.value = time;
+  }
+
+  dispose(scene) {
+    scene.remove(this.mesh);
+    this.geometry.dispose();
+    this.material.dispose();
+  }
+}
+
+function makeLogBandMap(binCount, bandCount, sampleRate) {
+  const nyquist = sampleRate / 2;
+  const fMin = 32;
+  const fMax = Math.min(16000, nyquist);
+  const bands = [];
+  for (let i = 0; i < bandCount; i++) {
+    const t0 = i / bandCount;
+    const t1 = (i + 1) / bandCount;
+    const f0 = fMin * Math.pow(fMax / fMin, t0);
+    const f1 = fMin * Math.pow(fMax / fMin, t1);
+    const b0 = Math.max(0, Math.floor((f0 / nyquist) * binCount));
+    const b1 = Math.min(binCount - 1, Math.ceil((f1 / nyquist) * binCount));
+    bands.push([b0, Math.max(b0 + 1, b1)]);
+  }
+  return bands;
+}
+
+class AuroraOrbitVisualizer {
+  constructor() {
+    this.container = null;
+    this.analyser = null;
+    this.renderer = null;
+    this.scene = null;
+    this.camera = null;
+    this.composer = null;
+    this.fxaaEffect = null;
+    this.bloomEffect = null;
+    this.points = null;
+    this.uniforms = null;
+    this.ribbons = [];
+    this.starfield = null;
+    this.simplex = new SimplexNoise(4711);
+    this.time = 0;
+    this.hueShift = 0;
+    this.quality = 'high';
+    this.qualitySettings = QUALITY_PRESETS.high;
+    this.bandMap = null;
+    this.audioState = {
+      energy: 0,
+      bass: 0,
+      mids: 0,
+      highs: 0,
+      sparkle: 0
+    };
+    this.lastBass = 0;
+    this.peakPulse = 0;
+    this.gradientUniforms = [new THREE.Color(), new THREE.Color(), new THREE.Color(), new THREE.Color()];
+    this.gradientWorkingColor = new THREE.Color();
+    this.gradientBaseHSL = BASE_GRADIENT.map((c) => ({ ...c }));
+    this.resizeObserver = null;
+    this.pixelRatio = 1;
+    this.width = 1;
+    this.height = 1;
+    this.minorRadius = 0.62;
+    this.contextLostHandler = null;
+  }
+
+  setQuality(level) {
+    if (!QUALITY_PRESETS[level]) return;
+    this.quality = level;
+    this.qualitySettings = QUALITY_PRESETS[level];
+    if (this.points) {
+      this._buildParticles();
+    }
+    if (this.ribbons.length) {
+      this._buildRibbons();
+    }
+    if (this.bloomEffect) {
+      this.bloomEffect.intensity = this.qualitySettings.bloom;
+    }
+  }
+
+  init(container, analyser) {
+    this.container = container;
+    this.analyser = analyser;
+    this.sampleRate = analyser.context.sampleRate || 44100;
+
+    const renderer = new THREE.WebGLRenderer({ antialias: false, alpha: false, powerPreference: 'high-performance' });
+    if (!renderer.getContext()) {
+      throw new Error('WebGL renderer not available');
+    }
+    this.renderer = renderer;
+    renderer.setPixelRatio(1);
+    renderer.setClearColor(0x05060a, 1);
+    renderer.domElement.className = 'aurora-orbit-webgl';
+    renderer.domElement.style.position = 'absolute';
+    renderer.domElement.style.inset = '0';
+    renderer.domElement.style.width = '100%';
+    renderer.domElement.style.height = '100%';
+    renderer.domElement.style.zIndex = '0';
+
+    this.container.insertBefore(renderer.domElement, this.container.firstChild);
+
+    renderer.domElement.addEventListener('webglcontextlost', (e) => {
+      e.preventDefault();
+      if (typeof this.contextLostHandler === 'function') {
+        this.contextLostHandler();
+      }
+    });
+
+    this.scene = new THREE.Scene();
+    this.scene.fog = new THREE.Fog(0x05060a, 12, 24);
+
+    this.camera = new THREE.PerspectiveCamera(55, 1, 0.1, 40);
+    this.camera.position.set(0, 0.6, 4.6);
+
+    this._buildParticles();
+    this._buildRibbons();
+    this._buildStarfield();
+    this._setupPost();
+
+    this.resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        this.resize(width, height);
+      }
+    });
+    this.resizeObserver.observe(this.container);
+  }
+
+  onContextLost(handler) {
+    this.contextLostHandler = handler;
+  }
+
+  _setupPost() {
+    if (!POSTPROCESSING) return;
+    const composer = new POSTPROCESSING.EffectComposer(this.renderer);
+    const renderPass = new POSTPROCESSING.RenderPass(this.scene, this.camera);
+    const fxaa = new POSTPROCESSING.FXAAEffect();
+    const bloom = new POSTPROCESSING.BloomEffect({
+      intensity: this.qualitySettings.bloom,
+      luminanceThreshold: 0.36,
+      luminanceSmoothing: 0.18,
+      radius: 0.85
+    });
+    bloom.blendMode.opacity.value = 1.0;
+    const effectPass = new POSTPROCESSING.EffectPass(this.camera, fxaa, bloom);
+    effectPass.renderToScreen = true;
+    composer.addPass(renderPass);
+    composer.addPass(effectPass);
+    this.composer = composer;
+    this.fxaaEffect = fxaa;
+    this.bloomEffect = bloom;
+  }
+
+  _buildStarfield() {
+    if (this.starfield) {
+      this.scene.remove(this.starfield);
+      this.starfield.geometry.dispose();
+      this.starfield.material.dispose();
+    }
+    this.starfield = makeStarfield(700, 18);
+    this.scene.add(this.starfield);
+  }
+
+  _buildParticles() {
+    if (this.points) {
+      this.points.geometry.dispose();
+      this.points.material.dispose();
+      this.scene.remove(this.points);
+    }
+
+    const count = this.qualitySettings.particles;
+    const { positions, angles, seeds } = makeTorusAttribute(count, 2.2, this.minorRadius);
+
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('aPosition', new THREE.BufferAttribute(positions, 3));
+    geometry.setAttribute('aAngles', new THREE.BufferAttribute(angles, 2));
+    geometry.setAttribute('aSeed', new THREE.BufferAttribute(seeds, 2));
+
+    const uniforms = {
+      uTime: { value: 0 },
+      uEnergy: { value: 0 },
+      uBass: { value: 0 },
+      uMids: { value: 0 },
+      uHighs: { value: 0 },
+      uHueShift: { value: 0 },
+      uSize: { value: 16.0 },
+      uBloomBoost: { value: 0 },
+      uMinorRadius: { value: this.minorRadius },
+      uSparkle: { value: 0 },
+      uGradient: { value: this.gradientUniforms }
+    };
+    this.uniforms = uniforms;
+
+    const vertexShader = `
+      precision mediump float;
+      attribute vec3 aPosition;
+      attribute vec2 aAngles;
+      attribute vec2 aSeed;
+      uniform float uTime;
+      uniform float uEnergy;
+      uniform float uBass;
+      uniform float uMids;
+      uniform float uHighs;
+      uniform float uSize;
+      uniform float uMinorRadius;
+      varying float vSpark;
+      varying float vGrad;
+      varying float vDepth;
+      const float PI = 3.14159265359;
+
+      // Simple hash for sparkle
+      float hash12(vec2 p){
+        vec3 p3 = fract(vec3(p.xyx) * 0.1031);
+        p3 += dot(p3, p3.yzx + 33.33);
+        return fract((p3.x + p3.y) * p3.z);
+      }
+
+      void main(){
+        float theta = aAngles.x;
+        float phi = aAngles.y;
+
+        float swing = sin(theta * 2.1 + uTime * 1.2 + aSeed.x * 6.283) * 0.25;
+        float minor = uMinorRadius * (1.0 + 0.08 * sin(uTime * 0.8 + aSeed.y * 10.0)) + swing * (0.5 + 0.8 * uBass);
+        float wobble = sin(phi * 3.0 + uTime * 1.7 + aSeed.y * 5.0) * 0.18;
+        minor += wobble * (0.4 + 0.7 * uMids);
+
+        float cosTheta = cos(theta);
+        float sinTheta = sin(theta);
+        float cosPhi = cos(phi);
+        float sinPhi = sin(phi);
+
+        float radius = 2.2 + (minor) * cosPhi;
+        vec3 pos;
+        pos.x = radius * cosTheta;
+        pos.y = (minor) * sinPhi;
+        pos.z = radius * sinTheta;
+
+        vec3 radial = normalize(vec3(cosTheta * cosPhi, sinPhi, sinTheta * cosPhi));
+        float shimmer = sin(uTime * 3.5 + aSeed.x * 14.0) * (0.03 + 0.05 * uHighs);
+        pos += radial * shimmer;
+
+        vec4 mvPosition = modelViewMatrix * vec4(pos, 1.0);
+        float dist = -mvPosition.z;
+        float size = uSize * (1.0 + 0.6 * uBass) * (1.0 + 0.3 * sin(theta * 4.0 + uTime + aSeed.x * 12.0));
+        gl_PointSize = size * (300.0 / max(dist, 40.0));
+        vDepth = clamp(1.0 - dist / 18.0, 0.0, 1.0);
+
+        float sparkleSeed = hash12(aSeed + uTime * 0.015);
+        float sparkleGate = step(0.82, sparkleSeed + uHighs * 0.25);
+        vSpark = sparkleGate * (0.25 + 1.4 * uHighs);
+        vGrad = clamp(0.3 + 0.6 * sin(phi + uTime * 0.35) + 0.2 * aSeed.x, 0.0, 1.0);
+
+        gl_Position = projectionMatrix * mvPosition;
+      }
+    `;
+
+    const fragmentShader = `
+      precision mediump float;
+      uniform vec3 uGradient[4];
+      uniform float uBloomBoost;
+      varying float vSpark;
+      varying float vGrad;
+      varying float vDepth;
+
+      vec3 gradient(float t){
+        vec3 c1 = mix(uGradient[0], uGradient[1], clamp(t, 0.0, 1.0));
+        vec3 c2 = mix(uGradient[2], uGradient[3], clamp(t, 0.0, 1.0));
+        float m = smoothstep(0.25, 0.85, t);
+        return mix(c1, c2, m);
+      }
+
+      void main(){
+        vec2 uv = gl_PointCoord - 0.5;
+        float d = dot(uv, uv);
+        if (d > 0.25) discard;
+        float falloff = pow(1.0 - d * 4.0, 1.6);
+        vec3 color = gradient(vGrad) * (0.55 + falloff * 0.6);
+        color += vec3(0.9, 0.85, 1.2) * vSpark * falloff;
+        color *= 1.0 + uBloomBoost * (0.4 + vDepth * 0.6);
+        float alpha = falloff * (0.45 + 0.55 * vDepth);
+        gl_FragColor = vec4(color, alpha);
+      }
+    `;
+
+    const material = new THREE.ShaderMaterial({
+      uniforms,
+      vertexShader,
+      fragmentShader,
+      transparent: true,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false
+    });
+
+    this.points = new THREE.Points(geometry, material);
+    this.scene.add(this.points);
+  }
+
+  _buildRibbons() {
+    for (const ribbon of this.ribbons) ribbon.dispose(this.scene);
+    this.ribbons = [];
+
+    const palettes = [
+      { h1: 200 / 360, s1: 0.8, l1: 0.52, h2: 280 / 360, s2: 0.72, l2: 0.55 },
+      { h1: 320 / 360, s1: 0.7, l1: 0.56, h2: 200 / 360, s2: 0.82, l2: 0.5 },
+      { h1: 50 / 360, s1: 0.65, l1: 0.6, h2: 200 / 360, s2: 0.78, l2: 0.55 },
+      { h1: 180 / 360, s1: 0.6, l1: 0.55, h2: 330 / 360, s2: 0.75, l2: 0.56 }
+    ];
+
+    for (let i = 0; i < this.qualitySettings.ribbons; i++) {
+      const palette = palettes[i % palettes.length];
+      this.ribbons.push(new AuroraRibbon(this.scene, this.qualitySettings.ribbonSegments, palette, this.simplex));
+    }
+  }
+
+  resize(width, height) {
+    if (!width || !height) return;
+    this.width = width;
+    this.height = height;
+    this.pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+
+    if (this.renderer) {
+      this.renderer.setPixelRatio(this.pixelRatio);
+      this.renderer.setSize(width, height);
+    }
+    if (this.camera) {
+      this.camera.aspect = width / height;
+      this.camera.updateProjectionMatrix();
+    }
+    if (this.composer) {
+      this.composer.setSize(width, height);
+      if (this.fxaaEffect) {
+        const resolution = this.fxaaEffect.resolution;
+        resolution.setResolution(width * this.pixelRatio, height * this.pixelRatio);
+      }
+    }
+  }
+
+  _computeAudioFeatures(freq, wave) {
+    if (!this.bandMap || this.bandMap.length !== 48 || this.bandMap[0][1] > freq.length) {
+      this.bandMap = makeLogBandMap(freq.length, 48, this.sampleRate);
+    }
+
+    let bassSum = 0, bassCount = 0;
+    let midsSum = 0, midsCount = 0;
+    let highsSum = 0, highsCount = 0;
+    let energySum = 0;
+
+    for (let i = 0; i < freq.length; i++) energySum += freq[i];
+
+    const nyquist = this.sampleRate / 2;
+    const binHz = nyquist / freq.length;
+    const bassMax = 200;
+    const midsMax = 2000;
+    const highsMax = 16000;
+
+    for (let i = 0; i < freq.length; i++) {
+      const hz = i * binHz;
+      const v = freq[i] / 255;
+      if (hz <= bassMax) { bassSum += v; bassCount++; }
+      else if (hz <= midsMax) { midsSum += v; midsCount++; }
+      else if (hz <= highsMax) { highsSum += v; highsCount++; }
+    }
+
+    let rms = 0;
+    for (let i = 0; i < wave.length; i++) {
+      const v = (wave[i] - 128) / 128;
+      rms += v * v;
+    }
+    rms = Math.sqrt(rms / wave.length);
+
+    const lerp = (a, b, t) => a + (b - a) * t;
+
+    const energy = energySum / (freq.length * 255);
+    this.audioState.energy = lerp(this.audioState.energy, Math.min(1, (energy + rms) * 0.7), 0.08);
+    this.audioState.bass = lerp(this.audioState.bass, bassCount ? bassSum / bassCount : 0, 0.12);
+    this.audioState.mids = lerp(this.audioState.mids, midsCount ? midsSum / midsCount : 0, 0.1);
+    this.audioState.highs = lerp(this.audioState.highs, highsCount ? highsSum / highsCount : 0, 0.1);
+    this.audioState.sparkle = lerp(this.audioState.sparkle, Math.pow(this.audioState.highs, 1.3), 0.18);
+  }
+
+  update(freq, wave, dt) {
+    if (!this.renderer || !this.uniforms) return;
+    this.time += dt;
+
+    this._computeAudioFeatures(freq, wave);
+
+    const audio = this.audioState;
+
+    this.hueShift += dt * (0.4 + audio.energy * 2.6);
+    const hueShift = this.hueShift;
+
+    const uniforms = this.uniforms;
+    uniforms.uTime.value = this.time;
+    uniforms.uEnergy.value = audio.energy;
+    uniforms.uBass.value = audio.bass;
+    uniforms.uMids.value = audio.mids;
+    uniforms.uHighs.value = audio.highs;
+    uniforms.uHueShift.value = hueShift;
+    uniforms.uSparkle.value = audio.sparkle;
+
+    const baseMinor = 0.62 * (1.0 + audio.bass * 0.12);
+    this.minorRadius = baseMinor;
+    uniforms.uMinorRadius.value = this.minorRadius;
+
+    const bloomBoost = Math.min(1.6, audio.energy * 1.2 + audio.highs * 0.6);
+    uniforms.uBloomBoost.value = bloomBoost;
+
+    if (this.bloomEffect) {
+      this.bloomEffect.intensity = this.qualitySettings.bloom * (1.0 + audio.energy * 0.5 + bloomBoost * 0.4);
+      this.bloomEffect.luminanceMaterial.threshold = 0.34 - Math.min(0.15, audio.energy * 0.12);
+      this.bloomEffect.luminanceMaterial.smoothing = 0.18 + audio.highs * 0.1;
+    }
+
+    const pulseTrigger = audio.bass > this.lastBass + 0.18 && audio.bass > 0.35;
+    if (pulseTrigger) this.peakPulse = 1.0;
+    this.peakPulse = Math.max(0, this.peakPulse - dt * 1.6);
+    this.lastBass = audio.bass;
+
+    const colors = this.gradientUniforms;
+    for (let i = 0; i < colors.length; i++) {
+      const base = this.gradientBaseHSL[i];
+      const color = colors[i];
+      const shiftedHue = (base.h + hueShift / (Math.PI * 2)) % 1;
+      this.gradientWorkingColor.setHSL((shiftedHue + 1) % 1, base.s, base.l).convertSRGBToLinear();
+      color.copy(this.gradientWorkingColor);
+    }
+
+    for (const ribbon of this.ribbons) {
+      ribbon.update(this.time, audio, this.minorRadius * (1.0 + audio.bass * 0.25), 0.45 + audio.energy * 0.4, hueShift);
+    }
+
+    if (this.starfield) {
+      this.starfield.rotation.y += dt * 0.02;
+      this.starfield.rotation.z += dt * 0.005;
+    }
+
+    const driftX = this.simplex.noise3D(this.time * 0.08, 11.3, 0) * 0.45;
+    const driftY = this.simplex.noise3D(0.7, this.time * 0.09, 5.1) * 0.25;
+    const driftZ = this.simplex.noise3D(4.2, 0.5, this.time * 0.06) * 0.3;
+    this.camera.position.x = 0.6 * Math.sin(this.time * 0.12) + driftX;
+    this.camera.position.y = 0.45 + driftY + audio.energy * 0.4;
+    this.camera.position.z = 4.6 + driftZ;
+
+    const pulse = this.peakPulse * 0.6;
+    const fovTarget = 55 + pulse * 1.8;
+    this.camera.fov += (fovTarget - this.camera.fov) * 0.08;
+    this.camera.rotation.z = pulse * 0.035 * Math.sin(this.time * 4.0);
+    this.camera.lookAt(0, 0, 0);
+    this.camera.updateProjectionMatrix();
+
+    const renderTarget = this.composer;
+    if (renderTarget) {
+      renderTarget.render(dt);
+    } else {
+      this.renderer.render(this.scene, this.camera);
+    }
+  }
+
+  dispose() {
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
+    }
+    if (this.points) {
+      this.scene.remove(this.points);
+      this.points.geometry.dispose();
+      this.points.material.dispose();
+      this.points = null;
+    }
+    if (this.starfield) {
+      this.scene.remove(this.starfield);
+      this.starfield.geometry.dispose();
+      this.starfield.material.dispose();
+      this.starfield = null;
+    }
+    for (const ribbon of this.ribbons) {
+      ribbon.dispose(this.scene);
+    }
+    this.ribbons = [];
+    if (this.composer) {
+      this.composer.dispose();
+      this.composer = null;
+    }
+    if (this.renderer) {
+      this.container.removeChild(this.renderer.domElement);
+      this.renderer.dispose();
+      this.renderer = null;
+    }
+    this.scene = null;
+    this.camera = null;
+  }
+}
+
+export { AuroraOrbitVisualizer };
+
+if (typeof window !== 'undefined') {
+  window.AuroraOrbitVisualizer = AuroraOrbitVisualizer;
+}

--- a/visualizers/aurora2d.js
+++ b/visualizers/aurora2d.js
@@ -1,0 +1,267 @@
+class AuroraOrbit2DVisualizer {
+  constructor() {
+    this.container = null;
+    this.canvas = null;
+    this.ctx = null;
+    this.width = 0;
+    this.height = 0;
+    this.dpr = 1;
+    this.analyser = null;
+    this.sampleRate = 44100;
+    this.bandMap = null;
+    this.barValues = new Float32Array(128);
+    this.sparkSeeds = new Float32Array(128);
+    this.audioState = {
+      energy: 0,
+      bass: 0,
+      mids: 0,
+      highs: 0
+    };
+    this.quality = 'high';
+    this.settings = { bars: 96, glow: 26, sparkCount: 180 };
+    this.bgGradient = null;
+    this.radialGradient = null;
+    this.lastHue = Math.random();
+    for (let i = 0; i < this.sparkSeeds.length; i++) {
+      this.sparkSeeds[i] = Math.random();
+    }
+  }
+
+  setQuality(level) {
+    const presets = {
+      high: { bars: 96, glow: 28, sparkCount: 220 },
+      medium: { bars: 72, glow: 22, sparkCount: 160 },
+      low: { bars: 56, glow: 18, sparkCount: 120 }
+    };
+    if (!presets[level]) return;
+    this.quality = level;
+    this.settings = presets[level];
+    this.barValues = new Float32Array(Math.max(this.settings.bars, this.barValues.length));
+    this.sparkSeeds = new Float32Array(Math.max(this.settings.sparkCount, this.sparkSeeds.length));
+    for (let i = 0; i < this.sparkSeeds.length; i++) {
+      this.sparkSeeds[i] = Math.random();
+    }
+    this.bandMap = null;
+  }
+
+  init(container, analyser) {
+    this.container = container;
+    this.analyser = analyser;
+    this.sampleRate = analyser.context.sampleRate || 44100;
+
+    let canvas = container.querySelector('#vis');
+    if (!canvas) {
+      canvas = document.createElement('canvas');
+      canvas.id = 'vis';
+      container.insertBefore(canvas, container.firstChild);
+    }
+    this.canvas = canvas;
+    canvas.style.position = 'absolute';
+    canvas.style.inset = '0';
+    canvas.style.width = '100%';
+    canvas.style.height = '100%';
+    canvas.style.zIndex = '0';
+    canvas.style.display = 'block';
+
+    this.ctx = canvas.getContext('2d', { alpha: false, desynchronized: true });
+    this.ctx.fillStyle = '#05060a';
+    this.ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }
+
+  resize(width, height) {
+    if (!this.canvas) return;
+    this.width = width;
+    this.height = height;
+    this.dpr = Math.min(window.devicePixelRatio || 1, 2);
+    this.canvas.width = Math.floor(width * this.dpr);
+    this.canvas.height = Math.floor(height * this.dpr);
+    this.canvas.style.width = width + 'px';
+    this.canvas.style.height = height + 'px';
+    this.ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
+    this._buildGradients();
+  }
+
+  _buildGradients() {
+    if (!this.ctx) return;
+    const ctx = this.ctx;
+    this.bgGradient = ctx.createLinearGradient(0, 0, 0, this.height);
+    this.bgGradient.addColorStop(0, '#041021');
+    this.bgGradient.addColorStop(0.6, '#09192e');
+    this.bgGradient.addColorStop(1, '#120920');
+
+    const r = Math.min(this.width, this.height) * 0.52;
+    this.radialGradient = ctx.createRadialGradient(this.width / 2, this.height / 2, r * 0.2, this.width / 2, this.height / 2, r);
+    this.radialGradient.addColorStop(0, 'rgba(34,68,120,0.6)');
+    this.radialGradient.addColorStop(1, 'rgba(5,8,12,0.05)');
+  }
+
+  _makeLogBandMap(binCount, bandCount) {
+    const nyquist = this.sampleRate / 2;
+    const fMin = 32;
+    const fMax = Math.min(16000, nyquist);
+    const bands = [];
+    for (let i = 0; i < bandCount; i++) {
+      const t0 = i / bandCount;
+      const t1 = (i + 1) / bandCount;
+      const f0 = fMin * Math.pow(fMax / fMin, t0);
+      const f1 = fMin * Math.pow(fMax / fMin, t1);
+      const b0 = Math.max(0, Math.floor((f0 / nyquist) * binCount));
+      const b1 = Math.min(binCount - 1, Math.ceil((f1 / nyquist) * binCount));
+      bands.push([b0, Math.max(b0 + 1, b1)]);
+    }
+    return bands;
+  }
+
+  _updateAudioStats(freq, wave) {
+    if (!this.bandMap || this.bandMap.length !== this.settings.bars || this.bandMap[0][1] > freq.length) {
+      this.bandMap = this._makeLogBandMap(freq.length, this.settings.bars);
+    }
+
+    const lerp = (a, b, t) => a + (b - a) * t;
+    let energySum = 0;
+    const nyquist = this.sampleRate / 2;
+    const binHz = nyquist / freq.length;
+    let bassSum = 0, bassCount = 0;
+    let midsSum = 0, midsCount = 0;
+    let highsSum = 0, highsCount = 0;
+
+    for (let i = 0; i < freq.length; i++) {
+      const v = freq[i] / 255;
+      energySum += v;
+      const hz = i * binHz;
+      if (hz <= 200) { bassSum += v; bassCount++; }
+      else if (hz <= 2000) { midsSum += v; midsCount++; }
+      else if (hz <= 16000) { highsSum += v; highsCount++; }
+    }
+
+    let rms = 0;
+    for (let i = 0; i < wave.length; i++) {
+      const v = (wave[i] - 128) / 128;
+      rms += v * v;
+    }
+    rms = Math.sqrt(rms / wave.length);
+
+    const energy = energySum / freq.length;
+    this.audioState.energy = lerp(this.audioState.energy, Math.min(1, (energy + rms) * 0.6), 0.12);
+    this.audioState.bass = lerp(this.audioState.bass, bassCount ? bassSum / bassCount : 0, 0.15);
+    this.audioState.mids = lerp(this.audioState.mids, midsCount ? midsSum / midsCount : 0, 0.14);
+    this.audioState.highs = lerp(this.audioState.highs, highsCount ? highsSum / highsCount : 0, 0.2);
+
+    const bars = this.settings.bars;
+    for (let i = 0; i < bars; i++) {
+      const [b0, b1] = this.bandMap[i];
+      let sum = 0;
+      for (let b = b0; b < b1; b++) sum += freq[b];
+      const avg = sum / (b1 - b0);
+      const target = Math.pow(avg / 255, 0.85);
+      this.barValues[i] = lerp(this.barValues[i] || 0, target, 0.25);
+    }
+  }
+
+  update(freq, wave, dt) {
+    if (!this.ctx) return;
+    this._updateAudioStats(freq, wave);
+    const ctx = this.ctx;
+    const W = this.width;
+    const H = this.height;
+
+    ctx.save();
+    ctx.fillStyle = this.bgGradient || '#05060a';
+    ctx.fillRect(0, 0, W, H);
+    if (this.radialGradient) {
+      ctx.fillStyle = this.radialGradient;
+      ctx.fillRect(0, 0, W, H);
+    }
+
+    const centerX = W / 2;
+    const centerY = H / 2;
+    const radius = Math.min(W, H) * 0.38;
+
+    ctx.translate(centerX, centerY);
+    ctx.rotate(-Math.PI / 2);
+
+    const bars = this.settings.bars;
+    const step = (Math.PI * 1.7) / bars;
+    const baseInner = radius * 0.55;
+    const glow = this.settings.glow;
+
+    ctx.lineCap = 'round';
+    ctx.shadowColor = 'rgba(114, 196, 255, 0.45)';
+    ctx.shadowBlur = glow;
+
+    const hueShift = (this.lastHue += dt * (0.05 + this.audioState.energy * 0.9));
+    const hueA = (0.58 + hueShift) % 1;
+    const hueB = (0.84 + hueShift * 0.6) % 1;
+
+    for (let i = 0; i < bars; i++) {
+      const v = this.barValues[i] || 0;
+      const angle = -Math.PI * 0.85 + i * step;
+      const thickness = 6 + v * 26;
+      const inner = baseInner * (0.82 + v * 0.12);
+      const outer = inner + radius * 0.32 * (0.3 + v * 0.9);
+      const grad = ctx.createLinearGradient(0, 0, Math.cos(angle), Math.sin(angle));
+      grad.addColorStop(0, `hsl(${Math.floor(hueA * 360)}, 85%, ${50 + v * 30}%)`);
+      grad.addColorStop(1, `hsl(${Math.floor(hueB * 360)}, 80%, ${55 + v * 28}%)`);
+      ctx.strokeStyle = grad;
+      ctx.lineWidth = thickness;
+      ctx.beginPath();
+      ctx.arc(0, 0, (inner + outer) * 0.5, angle - step * 0.42, angle + step * 0.42);
+      ctx.stroke();
+    }
+
+    ctx.shadowBlur = 0;
+
+    const energy = this.audioState.energy;
+    const bass = this.audioState.bass;
+    const mids = this.audioState.mids;
+    const highs = this.audioState.highs;
+
+    const pulseRadius = baseInner * (0.6 + bass * 0.4);
+    const pulseGradient = ctx.createRadialGradient(0, 0, pulseRadius * 0.3, 0, 0, pulseRadius);
+    pulseGradient.addColorStop(0, `rgba(255,255,255,${0.3 + energy * 0.4})`);
+    pulseGradient.addColorStop(1, 'rgba(20,30,40,0)');
+    ctx.fillStyle = pulseGradient;
+    ctx.beginPath();
+    ctx.arc(0, 0, pulseRadius, 0, Math.PI * 2);
+    ctx.fill();
+
+    const sparkCount = Math.min(this.settings.sparkCount, this.sparkSeeds.length);
+    ctx.lineWidth = 2.2;
+    ctx.strokeStyle = 'rgba(255,255,255,0.6)';
+    for (let i = 0; i < sparkCount; i++) {
+      const seed = this.sparkSeeds[i];
+      const angle = seed * Math.PI * 2 + i * 0.1 + this.lastHue * 2.0;
+      const length = radius * (0.18 + 0.22 * highs + (seed % 0.3));
+      const offset = radius * 0.65 + Math.sin(angle * 3.1 + mids * 4.0) * 12;
+      const alpha = 0.15 + highs * 0.5;
+      ctx.globalAlpha = alpha;
+      ctx.beginPath();
+      ctx.moveTo(Math.cos(angle) * offset, Math.sin(angle) * offset);
+      ctx.lineTo(Math.cos(angle) * (offset + length), Math.sin(angle) * (offset + length));
+      ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+
+    ctx.restore();
+
+    ctx.fillStyle = 'rgba(0,0,0,0.35)';
+    ctx.fillRect(0, 0, W, H);
+    const vignette = ctx.createRadialGradient(W / 2, H / 2, Math.min(W, H) * 0.45, W / 2, H / 2, Math.max(W, H) * 0.7);
+    vignette.addColorStop(0, 'rgba(0,0,0,0)');
+    vignette.addColorStop(1, 'rgba(0,0,0,0.45)');
+    ctx.fillStyle = vignette;
+    ctx.fillRect(0, 0, W, H);
+  }
+
+  dispose() {
+    if (this.canvas && this.ctx) {
+      this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    }
+  }
+}
+
+export { AuroraOrbit2DVisualizer };
+
+if (typeof window !== 'undefined') {
+  window.AuroraOrbit2DVisualizer = AuroraOrbit2DVisualizer;
+}


### PR DESCRIPTION
## Summary
- add the Aurora Orbit WebGL visualizer with torus particles, neon ribbons, bloom/FXAA postprocessing, and quality presets
- implement a Canvas2D Aurora Orbit fallback visualizer that mirrors the audio-driven aesthetics when WebGL is unavailable
- refactor the player app to manage visualizer selection, resizing, quality switching, and load the Three.js/postprocessing dependencies

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d46ff6f06c83298cd8e1df2b105866