### PR TITLE
Switch aurora visualizer to module imports

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,8 +53,6 @@
   </footer>
 
   <audio id="audio" crossorigin="anonymous"></audio>
-  <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
-  <script src="https://unpkg.com/postprocessing@6.35.3/build/postprocessing.min.js"></script>
   <script type="module" src="visualizers/aurora.js"></script>
   <script type="module" src="visualizers/aurora2d.js"></script>
   <script type="module" src="app.js"></script>

--- a/visualizers/aurora.js
+++ b/visualizers/aurora.js
@@ -1,9 +1,11 @@
-const THREE = window.THREE;
-const POSTPROCESSING = window.POSTPROCESSING;
-
-if (!THREE) {
-  throw new Error("Three.js is required for AuroraOrbitVisualizer");
-}
+import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+import {
+  EffectComposer,
+  RenderPass,
+  EffectPass,
+  FXAAEffect,
+  BloomEffect
+} from 'https://unpkg.com/postprocessing@6.35.3/build/postprocessing.esm.js';
 
 // Lightweight seeded simplex noise for smooth procedural motion.
 class SimplexNoise {
@@ -516,18 +518,18 @@ class AuroraOrbitVisualizer {
   }
 
   _setupPost() {
-    if (!POSTPROCESSING) return;
-    const composer = new POSTPROCESSING.EffectComposer(this.renderer);
-    const renderPass = new POSTPROCESSING.RenderPass(this.scene, this.camera);
-    const fxaa = new POSTPROCESSING.FXAAEffect();
-    const bloom = new POSTPROCESSING.BloomEffect({
+    if (!this.renderer || !this.camera) return;
+    const composer = new EffectComposer(this.renderer);
+    const renderPass = new RenderPass(this.scene, this.camera);
+    const fxaa = new FXAAEffect();
+    const bloom = new BloomEffect({
       intensity: this.qualitySettings.bloom,
       luminanceThreshold: 0.36,
       luminanceSmoothing: 0.18,
       radius: 0.85
     });
     bloom.blendMode.opacity.value = 1.0;
-    const effectPass = new POSTPROCESSING.EffectPass(this.camera, fxaa, bloom);
+    const effectPass = new EffectPass(this.camera, fxaa, bloom);
     effectPass.renderToScreen = true;
     composer.addPass(renderPass);
     composer.addPass(effectPass);
@@ -718,8 +720,20 @@ class AuroraOrbitVisualizer {
     if (this.composer) {
       this.composer.setSize(width, height);
       if (this.fxaaEffect) {
-        const resolution = this.fxaaEffect.resolution;
-        resolution.setResolution(width * this.pixelRatio, height * this.pixelRatio);
+        const targetWidth = width * this.pixelRatio;
+        const targetHeight = height * this.pixelRatio;
+        if (typeof this.fxaaEffect.setSize === 'function') {
+          this.fxaaEffect.setSize(targetWidth, targetHeight);
+        } else if (this.fxaaEffect.resolution) {
+          const resolution = this.fxaaEffect.resolution;
+          if (typeof resolution.set === 'function') {
+            resolution.set(targetWidth, targetHeight);
+          } else if (typeof resolution.setSize === 'function') {
+            resolution.setSize(targetWidth, targetHeight);
+          } else if (typeof resolution.setResolution === 'function') {
+            resolution.setResolution(targetWidth, targetHeight);
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- switch the aurora visualizer to use ES module imports for three.js and postprocessing
- update the FXAA resize handling to work with the current postprocessing API and avoid accessing undefined resolution helpers
- remove the deprecated global script includes from the main page now that modules are used directly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5a8bc79e483299d56fd2fe71521e2