### PR TITLE
Fix duplicate module imports in aurora visualizer

### DIFF
--- a/visualizers/aurora.js
+++ b/visualizers/aurora.js
@@ -1,5 +1,4 @@
 import * as THREE from '../modules/three.module.js';
-import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
 import {
   EffectComposer,
   RenderPass,
@@ -7,7 +6,6 @@ import {
   FXAAEffect,
   BloomEffect
 } from '../modules/postprocessing.js';
-} from 'https://unpkg.com/postprocessing@6.35.3/build/postprocessing.esm.js';
 
 // Lightweight seeded simplex noise for smooth procedural motion.
 class SimplexNoise {


### PR DESCRIPTION
## Summary
- remove the redundant CDN imports in `visualizers/aurora.js` so the module only pulls THREE.js and postprocessing from the local bundle

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d5accdfe948329a081c2a9eb3c14cd