### PR TITLE
Enhance aurora visualizer with vibrant 3D experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Local Jukebox + Visualizer</title>
   <link rel="stylesheet" href="styles.css" />
+  <link rel="modulepreload" href="modules/three.module.js" />
+  <link rel="modulepreload" href="modules/postprocessing.js" />
 </head>
 <body>
   <header class="app-header">
@@ -53,6 +55,15 @@
   </footer>
 
   <audio id="audio" crossorigin="anonymous"></audio>
+  <script>
+    window.AURORA_VENDOR_MODULES = Object.assign(
+      {
+        three: './modules/three.module.js',
+        postprocessing: './modules/postprocessing.js'
+      },
+      window.AURORA_VENDOR_MODULES || {}
+    );
+  </script>
   <script type="module" src="visualizers/aurora.js"></script>
   <script type="module" src="visualizers/aurora2d.js"></script>
   <script type="module" src="app.js"></script>


### PR DESCRIPTION
## Summary
- load Three.js and postprocessing modules dynamically with a local-or-CDN fallback and preload them from index.html
- rebuild the WebGL aurora visualizer with brighter gradients, deterministic torus particles, twinkling starfield, expressive ribbons, and richer audio-driven motion
- tune post-processing, camera drift, and bloom so bass, mids, and highs drive depth, sparkle, and glow across quality presets

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d5b19398588329a5187fa2f775364e